### PR TITLE
Use OMP's native to hide the dialog

### DIFF
--- a/inventory-dialog.inc
+++ b/inventory-dialog.inc
@@ -238,7 +238,11 @@ stock ClosePlayerInventory(playerid, call = false) {
 		}
 	}
 
-	ShowPlayerDialog(playerid, -1, 0, NULL, NULL, NULL, NULL);
+	#if defined HidePlayerDialog
+		HidePlayerDialog(playerid);
+	#else
+		ShowPlayerDialog(playerid, -1, 0, NULL, NULL, NULL, NULL);
+	#endif
 	inv_ViewingInventory[playerid] = false;
 
 	return 0;


### PR DESCRIPTION
Only if it's defined, so the library still works in samp.