### PR TITLE
Fix 'Move to <container>' appearing out of context

### DIFF
--- a/inventory-dialog.inc
+++ b/inventory-dialog.inc
@@ -21,6 +21,7 @@
 #include <tick-difference>
 #include <item>
 #include <inventory>
+#include <container-dialog>
 #include <YSI_Visual\y_dialog>
 
 #include <YSI_Coding\y_hooks>
@@ -238,11 +239,7 @@ stock ClosePlayerInventory(playerid, call = false) {
 		}
 	}
 
-	#if defined HidePlayerDialog
-		HidePlayerDialog(playerid);
-	#else
-		ShowPlayerDialog(playerid, -1, 0, NULL, NULL, NULL, NULL);
-	#endif
+	ClosePlayerContainer(playerid);
 	inv_ViewingInventory[playerid] = false;
 
 	return 0;

--- a/pawn.json
+++ b/pawn.json
@@ -7,6 +7,7 @@
 		"sampctl/samp-stdlib",
 		"pawn-lang/YSI-Includes",
 		"ScavengeSurvive/inventory",
+		"ScavengeSurvive/container-dialog",
 		"ScavengeSurvive/item",
 		"ScavengeSurvive/tick-difference"
 	],


### PR DESCRIPTION
Let's say you opened a container by a nearby button.
You could switch to the inventory view, close it (by triggering !response) and then move somewhere far away.
If you had done that, the "move to <container>" option would be still there. Even though you closed all the dialogs coming from that context long time ago.
It's all because `cnt_CurrentContainer` from the `container-dialog` can't be reset.

Another option would be to make a getter and setter for `cnt_CurrentContainer` and extend the `ClosePlayerInventory` but I don't think it brings any real value, at least for my use-cases.

An inventory is still a container, so I believe most people use those 2 together and adding container-dialog as a dependency should be all right.